### PR TITLE
MediaSession API implementation

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,5 +1,5 @@
 var MusicPlayer = (function () {
-
+  
   function createEvent(event, props) {
     if (typeof CustomEvent === 'function') {
       return new CustomEvent(event, props)
@@ -21,6 +21,8 @@ var MusicPlayer = (function () {
     else {
       this.audio = new Audio()
     }
+
+    this.shouldUseMediaSession = 'mediaSession' in navigator
     this.audio.addEventListener('error', onError.bind(this))
     this.audio.addEventListener('stalled', onStalled.bind(this))
     this.audio.addEventListener('ended', onEnded.bind(this))
@@ -35,6 +37,17 @@ var MusicPlayer = (function () {
     this.repeatMode = 'none'
     this.shuffle = false
     this.clear()
+
+    if(this.shouldUseMediaSession) {
+      // Need to do this since `this` in the scope of
+      // the action handler is actually the MediaSession :(
+      var self = this
+
+      // The `pause` event actually handles both playing and pausing -- so no need to define both
+      navigator.mediaSession.setActionHandler('pause', function() { self.pause() })
+      navigator.mediaSession.setActionHandler('previoustrack', function() { self.previous() })
+      navigator.mediaSession.setActionHandler('nexttrack', function() { self.next() })
+    }
   }
 
   MusicPlayer.prototype.add = function (item) {
@@ -76,6 +89,24 @@ var MusicPlayer = (function () {
     this.audio.play()
     this.index = index
 
+    if(this.shouldUseMediaSession) {
+      // Set up media session metadata
+      var track = this.items[index]
+      
+      // This `if` is here to prevent the MediaSession from
+      // abruptly disappearing from the device and then
+      // reappearing
+      if(navigator.mediaSession.metadata === null) {
+        navigator.mediaSession.metadata = new MediaMetadata({
+          title: track.title,
+          artist: track.artistTitle
+        })
+      } else {
+        navigator.mediaSession.metadata.title = track.title
+        navigator.mediaSession.metadata.artist = track.artistTitle
+      }
+    }
+
     this.trigger('play')
   }
 
@@ -106,6 +137,8 @@ var MusicPlayer = (function () {
   }
 
   MusicPlayer.prototype.stop = function () {
+    // Kill the MediaSession if needed
+    if(this.shouldUseMediaSession) navigator.mediaSession.metadata = null
     this.audio.pause()
     this.seek(0)
     this.trigger('stop')

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -39,8 +39,6 @@ var MusicPlayer = (function () {
     this.clear()
 
     if (this.shouldUseMediaSession) {
-      // Need to do this since `this` in the scope of
-      // the action handler is actually the MediaSession :(
       var self = this
 
       // The `pause` event actually handles both playing and pausing -- so no need to define both
@@ -137,7 +135,6 @@ var MusicPlayer = (function () {
   }
 
   MusicPlayer.prototype.stop = function () {
-    // Kill the MediaSession if needed
     if (this.shouldUseMediaSession)
       navigator.mediaSession.metadata = null
     this.audio.pause()

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -38,15 +38,15 @@ var MusicPlayer = (function () {
     this.shuffle = false
     this.clear()
 
-    if(this.shouldUseMediaSession) {
+    if (this.shouldUseMediaSession) {
       // Need to do this since `this` in the scope of
       // the action handler is actually the MediaSession :(
       var self = this
 
       // The `pause` event actually handles both playing and pausing -- so no need to define both
-      navigator.mediaSession.setActionHandler('pause', function() { self.pause() })
-      navigator.mediaSession.setActionHandler('previoustrack', function() { self.previous() })
-      navigator.mediaSession.setActionHandler('nexttrack', function() { self.next() })
+      navigator.mediaSession.setActionHandler('pause', () => self.pause())
+      navigator.mediaSession.setActionHandler('previoustrack', () => self.previous())
+      navigator.mediaSession.setActionHandler('nexttrack', () => self.next())
     }
   }
 
@@ -89,14 +89,14 @@ var MusicPlayer = (function () {
     this.audio.play()
     this.index = index
 
-    if(this.shouldUseMediaSession) {
+    if (this.shouldUseMediaSession) {
       // Set up media session metadata
       var track = this.items[index]
       
       // This `if` is here to prevent the MediaSession from
       // abruptly disappearing from the device and then
       // reappearing
-      if(navigator.mediaSession.metadata === null) {
+      if (navigator.mediaSession.metadata === null) {
         navigator.mediaSession.metadata = new MediaMetadata({
           title: track.title,
           artist: track.artistTitle
@@ -138,7 +138,8 @@ var MusicPlayer = (function () {
 
   MusicPlayer.prototype.stop = function () {
     // Kill the MediaSession if needed
-    if(this.shouldUseMediaSession) navigator.mediaSession.metadata = null
+    if (this.shouldUseMediaSession)
+      navigator.mediaSession.metadata = null
     this.audio.pause()
     this.seek(0)
     this.trigger('stop')


### PR DESCRIPTION
This pull request is for issue #314.

---

This is similar to PR #317, but it implements MediaSession directly in the `MusicPlayer` class instead of the controls and uses less code. It also fixes an issue with that implementation, namely that the MediaSession would not exist abruptly when changing song, since a new `MediaMetadata` object was created every time a song started playing. So as a result, the notification displaying the music would disappear then reappear, which is definitely not ideal when trying to skip songs...

This was tested on Chrome 58 on an Android virtual device running Oreo 8.0. I tried to comment what I was doing where appropriate 🙂

## Demo

![](https://thumbs.gfycat.com/GiftedHeavenlyIguana-size_restricted.gif)