### PR TITLE
Removed display:none from volume slider

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -462,10 +462,6 @@ body.showing-notice .controls.fixed.playing {
   opacity: 1;
   pointer-events: auto;
 }
-.controls > .volume-slider-container,
-.controls > .volume-toggle{
-  display: none;
-}
 
 @media screen and (min-width:992px) {
   .controls > .volume-slider-container,


### PR DESCRIPTION
Fixes https://github.com/monstercat/deon/issues/366
![screenshot_2018-07-05 waterval by hush - monstercat](https://user-images.githubusercontent.com/38556644/42322968-5315e87a-8056-11e8-8a52-fe24d7994274.png)
