### PR TITLE
Fix allow toggling volume mute by clicking icon

### DIFF
--- a/src/html/body.html
+++ b/src/html/body.html
@@ -158,7 +158,7 @@ window.fbAsyncInit = function() {
             <button class="faux" onclick="toggleRepeat(event, this)">
                 <i class="fa fa-repeat"></i>
             </button>
-            <button class="faux volume-toggle" onclick="toggleVolume(event)" role="volumeControl" onmouseover="startVolumeSliderShow(event)" onmouseleave="startVolumeSliderHide()">
+            <button class="faux volume-toggle" onclick="toggleVolume(event, this)" role="volumeControl" onmouseover="startVolumeSliderShow(event)" onmouseleave="startVolumeSliderHide()">
                 <i class="fa fa-volume-up"></i>
             </button>
         </div>

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -140,10 +140,6 @@ function playSong (e, el) {
 }
 
 function toggleVolume (e, el) {
-  if (!el.matches(e.target, 'i,button')) {
-    return
-  }
-
   var volume = player.getVolume()
 
   if (volume > 0) {


### PR DESCRIPTION
Currently clicking the volume icon does not mute the volume, and throws a JavaScript errors.
This fixes it by passing the el in correctly.